### PR TITLE
Handle response

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -3,68 +3,68 @@
 // register handlers
 exports.register = function(server, middleware) {
     // api get cluster state
-    server.get('/:api_version/cluster/state', middleware.get_handler('cluster', 'state'));
+    server.get('/:api_version/cluster/state', middleware.get_handler('cluster', 'state'), middleware.handle_response);
 
     // shutdown containership processes across cluster
-    server.delete('/:api_version/cluster', middleware.get_handler('cluster', 'delete'));
+    server.delete('/:api_version/cluster', middleware.get_handler('cluster', 'delete'), middleware.handle_response);
 
     // api get applications
-    server.get('/:api_version/applications', middleware.get_handler('applications', 'get'));
+    server.get('/:api_version/applications', middleware.get_handler('applications', 'get'), middleware.handle_response);
 
     // api create applications
-    server.post('/:api_version/applications', middleware.get_handler('applications', 'create'));
+    server.post('/:api_version/applications', middleware.get_handler('applications', 'create'), middleware.handle_response);
 
     // api get application
-    server.get('/:api_version/applications/:application', middleware.get_handler('application', 'get'));
+    server.get('/:api_version/applications/:application', middleware.get_handler('application', 'get'), middleware.handle_response);
 
     // api create application
-    server.post('/:api_version/applications/:application', middleware.get_handler('application', 'create'));
+    server.post('/:api_version/applications/:application', middleware.get_handler('application', 'create'), middleware.handle_response);
 
     // api update application
-    server.put('/:api_version/applications/:application', middleware.get_handler('application', 'update'));
+    server.put('/:api_version/applications/:application', middleware.get_handler('application', 'update'), middleware.handle_response);
 
     // api delete application
-    server.delete('/:api_version/applications/:application', middleware.get_handler('application', 'delete'));
+    server.delete('/:api_version/applications/:application', middleware.get_handler('application', 'delete'), middleware.handle_response);
 
     // api get application containers
-    server.get('/:api_version/applications/:application/containers', middleware.get_handler('application', 'get_containers'));
+    server.get('/:api_version/applications/:application/containers', middleware.get_handler('application', 'get_containers'), middleware.handle_response);
 
     // api create application container
-    server.post('/:api_version/applications/:application/containers', middleware.get_handler('application', 'create_containers'));
+    server.post('/:api_version/applications/:application/containers', middleware.get_handler('application', 'create_containers'), middleware.handle_response);
 
     // api delete application containers
-    server.delete('/:api_version/applications/:application/containers', middleware.get_handler('application', 'remove_containers'));
+    server.delete('/:api_version/applications/:application/containers', middleware.get_handler('application', 'remove_containers'), middleware.handle_response);
 
     // api get application container
-    server.get('/:api_version/applications/:application/containers/:container', middleware.get_handler('application', 'get_container'));
+    server.get('/:api_version/applications/:application/containers/:container', middleware.get_handler('application', 'get_container'), middleware.handle_response);
 
     // api delete application container
-    server.delete('/:api_version/applications/:application/containers/:container', middleware.get_handler('application', 'remove_container'));
+    server.delete('/:api_version/applications/:application/containers/:container', middleware.get_handler('application', 'remove_container'), middleware.handle_response);
 
     // api get hosts
-    server.get('/:api_version/hosts', middleware.get_handler('hosts', 'get'));
+    server.get('/:api_version/hosts', middleware.get_handler('hosts', 'get'), middleware.handle_response);
 
     // api get host
-    server.get('/:api_version/hosts/:host', middleware.get_handler('host', 'get'));
+    server.get('/:api_version/hosts/:host', middleware.get_handler('host', 'get'), middleware.handle_response);
 
     // api update host
-    server.put('/:api_version/hosts/:host', middleware.get_handler('host', 'update'));
+    server.put('/:api_version/hosts/:host', middleware.get_handler('host', 'update'), middleware.handle_response);
 
     // api delete host
-    server.delete('/:api_version/hosts/:host', middleware.get_handler('host', 'delete'));
+    server.delete('/:api_version/hosts/:host', middleware.get_handler('host', 'delete'), middleware.handle_response);
 
     // api get variables
-    server.get('/:api_version/variables', middleware.get_handler('variables', 'get'));
+    server.get('/:api_version/variables', middleware.get_handler('variables', 'get'), middleware.handle_response);
 
     // api create variable
-    server.post('/:api_version/variables/:variable', middleware.get_handler('variable', 'create'));
+    server.post('/:api_version/variables/:variable', middleware.get_handler('variable', 'create'), middleware.handle_response);
 
     // api get variable
-    server.get('/:api_version/variables/:variable', middleware.get_handler('variable', 'get'));
+    server.get('/:api_version/variables/:variable', middleware.get_handler('variable', 'get'), middleware.handle_response);
 
     // api update variable
-    server.put('/:api_version/variables/:variable', middleware.get_handler('variable', 'update'));
+    server.put('/:api_version/variables/:variable', middleware.get_handler('variable', 'update'), middleware.handle_response);
 
     // api delete variable
-    server.delete('/:api_version/variables/:variable', middleware.get_handler('variable', 'delete'));
+    server.delete('/:api_version/variables/:variable', middleware.get_handler('variable', 'delete'), middleware.handle_response);
 };

--- a/lib/server.js
+++ b/lib/server.js
@@ -43,8 +43,8 @@ Server.prototype.start = function() {
     // register the routes
     this.routes.register(this.server, this.middleware);
 
-    // handle Response
-    this.server.use(this.middleware.handle_response);
+    // cannot register handle response middleware here because plugins can
+    // dynamically register routes but it would happen after server initialization
 
     // start listening
     this.server.listen(this.core.options['api-port'], this.core.options['api-interface']);


### PR DESCRIPTION
We cannot move `handle_response` to the global middleware because plugins register dynamically and this happens after server instantiation.

@ashleyschuett @normanjoyner 