### PR TITLE
added fix if a container is still marked as being on a peer that no l…

### DIFF
--- a/handlers/v1/hosts.js
+++ b/handlers/v1/hosts.js
@@ -59,7 +59,7 @@ module.exports = {
                                 container = JSON.parse(container);
                                 const application = container_name.split(core.constants.myriad.DELIMITER)[2];
                                 container.application = application;
-                                hosts[container.host].containers.push(container);
+                                hosts[container.host] && hosts[container.host].containers.push(container);
                             } catch(err) {
                                 return fn(err);
                             }


### PR DESCRIPTION
…onger exists

found this to be an issue that crashed the /hosts call of the api on deletion of a follower. 